### PR TITLE
Add GH action for storybook deploys

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -1,0 +1,18 @@
+name: "Deploy Storybook to Github Pages"
+
+on:
+  push:
+    branches:
+      - main
+    paths: ["stories/**", "src/components/**", "README.md"]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Deploy Storybook
+      run: npm run deploy-storybook


### PR DESCRIPTION
Adds a Github Action for storybook deploys on the main branch for testing purposes. The path checks for changes to the README,  Stories, and, Components.